### PR TITLE
upgrade maven-checkstyle-plugin to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.17</version>
+          <version>3.1.1</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.apex</groupId>


### PR DESCRIPTION
This PR will upgrade maven-checkstyle-plugin to 3.1.1 for Checkstyle's regression testing.

Related to Issue:
Issue: checkstyle/checkstyle/issues/7190
PR: checkstyle/checkstyle#7778