### PR TITLE
config: add checkstyle version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
     <license.skip>true</license.skip>
     <findbugs.xmlOutput>true</findbugs.xmlOutput>
     <findbugs.failOnError>false</findbugs.failOnError>
+    <checkstyle.version>6.15</checkstyle.version>
     <dependency.check.failBuildOnCVSS>8</dependency.check.failBuildOnCVSS>
     <dependency.check.showSummary>true</dependency.check.showSummary>
     <dependency.check.whitelist>${project.basedir}/../dependency-check-whitelist.xml</dependency.check.whitelist>
@@ -403,7 +404,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>6.15</version>
+              <version>${checkstyle.version}</version>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
Changes are needed in this repo to get main checkstyle project to work. Wercker is failing in master as it is now.

This is PR 1 to allow checkstyle to override the property version. We need a second PR to upgrade the config to the latest version if it has breaking changes. It is using a very old config. Even with upgrading config we may have new violations to fix to use it in no error regression, unless we switch to no exception regression.